### PR TITLE
Blobs: splitup between common and device specic trees.

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -2,8 +2,50 @@
 vendor/firmware/bcm4358A3_V0062.0104.hcd
 
 ### GPS
+bin/gpsd
 lib/libwrappergps.so
+lib/hw/gps.universal5433.so
+
+### Mobicore
+app/FFFFFFFF000000000000000000000001.drbin
+app/mcRegistry/07010000000000000000000000000000.tlbin
+app/mcRegistry/08130000000000000000000000000000.tlbin
+app/mcRegistry/07060000000000000000000000000000.tlbin
+app/mcRegistry/00060308060501020000000000000000.tlbin
+app/mcRegistry/02010000080300030000000000000000.tlbin
+app/mcRegistry/ffffffff00000000000000000000000a.tlbin
+app/mcRegistry/ffffffff00000000000000000000000b.tlbin
+app/mcRegistry/ffffffff00000000000000000000000c.tlbin
+app/mcRegistry/ffffffff00000000000000000000000d.tlbin
+app/mcRegistry/ffffffff00000000000000000000000e.tlbin
+app/mcRegistry/ffffffff00000000000000000000000f.tlbin
+app/mcRegistry/ffffffff00000000000000000000001f.tlbin
+app/mcRegistry/ffffffff00000000000000000000003e.tlbin
+app/mcRegistry/ffffffff000000000000000000000004.tlbin
+app/mcRegistry/ffffffff000000000000000000000005.tlbin
+app/mcRegistry/ffffffff000000000000000000000011.tlbin
+app/mcRegistry/ffffffff000000000000000000000012.tlbin
+app/mcRegistry/ffffffff000000000000000000000013.tlbin
+app/mcRegistry/ffffffff000000000000000000000016.tlbin
+app/mcRegistry/ffffffff000000000000000000000017.tlbin
+app/mcRegistry/ffffffff000000000000000000000018.tlbin
+app/mcRegistry/ffffffff000000000000000000000019.tlbin
+app/mcRegistry/ffffffff000000000000000000000021.tlbin
+app/mcRegistry/ffffffff000000000000000000000041.tlbin
+app/mcRegistry/ffffffffd0000000000000000000000a.tlbin
+app/mcRegistry/ffffffffd0000000000000000000000e.tlbin
+app/mcRegistry/ffffffffd00000000000000000000004.tlbin
+app/mcRegistry/ffffffffd00000000000000000000016.tlbin
+app/mcRegistry/fffffffff0000000000000000000001e.tlbin
 
 ### RIL
 bin/cbd
 lib/libsec-ril.so
+
+### Wifi
+etc/wifi/nvram_mfg.txt
+etc/wifi/nvram_mfg.txt_4356_a2
+etc/wifi/nvram_mfg.txt_4358_a1
+etc/wifi/nvram_net.txt
+etc/wifi/nvram_net.txt_4356_a2
+etc/wifi/nvram_net.txt_4358_a1


### PR DESCRIPTION
Splitup is needed as added blobs have different content on T710/715/810
and 815.

Change-Id: Ib79589a0f2a5470cbf7244310f5d5b3afa8d4520